### PR TITLE
Allow passing additional origins and behaviors to tf_next module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -452,10 +452,10 @@ locals {
     })
   }
 
-  cloudfront_origins = {
+  cloudfront_origins = merge({
     for key, origin in local._cloudfront_origins : key => origin
     if origin.create
-  }
+  }, { for origin in var.cloudfront_origins : origin.origin_id => origin })
 
   # CloudFront behaviors
   ######################
@@ -494,10 +494,10 @@ locals {
     })
   }
 
-  cloudfront_ordered_cache_behaviors = {
+  cloudfront_ordered_cache_behaviors = merge({
     for key, behavior in local._cloudfront_ordered_cache_behaviors : key => behavior
     if behavior.create
-  }
+  }, { for behavior in var.cloudfront_ordered_cache_behaviors : behavior.target_origin_id => behavior })
 
   cloudfront_custom_error_response = {
     s3_failover = {

--- a/variables.tf
+++ b/variables.tf
@@ -140,6 +140,16 @@ variable "cloudfront_webacl_id" {
   default     = null
 }
 
+variable "cloudfront_origins" {
+  type    = any
+  default = null
+}
+
+variable "cloudfront_ordered_cache_behaviors" {
+  type    = any
+  default = null
+}
+
 ##########
 # Labeling
 ##########


### PR DESCRIPTION
We need ability to configure additional origins/behaviors on main CDN to add apis, static files etc.
This PR adds this feature to tf-next.